### PR TITLE
Removed the deprecated 'bottle :unneeded' lines.

### DIFF
--- a/octool.rb
+++ b/octool.rb
@@ -3,7 +3,6 @@ class Octool < Formula
   desc "Simple tool to test/debug/diagnose connections to OpenConfig servers"
   homepage "https://github.com/vapor-ware/octool"
   version "0.1.0-rc1"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/vapor-ware/octool/releases/download/v0.1.0-rc1/octool_0.1.0-rc1_darwin_amd64.tar.gz"

--- a/ouroboros.rb
+++ b/ouroboros.rb
@@ -3,7 +3,6 @@ class Ouroboros < Formula
   desc "A Helm(file) toolkit designed to flatten the curve for knowledge required to perform deployments at Vapor."
   homepage "https://github.com/vapor-ware/ouroboros"
   version "0.1.0-rc.3"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/vapor-ware/ouroboros/releases/download/0.1.0-rc.3/ouroboros_0.1.0-rc.3_darwin_amd64.tar.gz"

--- a/sctl.rb
+++ b/sctl.rb
@@ -3,7 +3,6 @@ class Sctl < Formula
   desc "Manage secrets on Google Cloud Platform with KMS and state files"
   homepage "https://github.com/vapor-ware/sctl"
   version "1.5.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/vapor-ware/sctl/releases/download/1.5.0/sctl_1.5.0_Darwin_x86_64.tar.gz"

--- a/synse.rb
+++ b/synse.rb
@@ -3,7 +3,6 @@ class Synse < Formula
   desc "Unified CLI for Vapor IO's Synse platform."
   homepage "https://github.com/vapor-ware/synse-cli"
   version "3.0.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/vapor-ware/synse-cli/releases/download/3.0.0/synse_3.0.0_darwin_amd64.tar.gz"


### PR DESCRIPTION
This was causing issues in newer versions of homebrew.